### PR TITLE
docs(readme): corrigir link do ServeRest

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@
 
 - [Linkedin](https://www.linkedin.com/in/lopesdoamaral/)
 
-[![ServeRest API](https://img.shields.io/badge/API-ServeRest-green?style=for-the-badge)](https://serverest.js.org/)
+[![ServeRest API](https://img.shields.io/badge/API-ServeRest-green?style=for-the-badge)](https://github.com/PauloGoncalvesBH/ServeRest)
 - Execute o comando 
     - `$ npx serverest -p 3500 -t 3600 --nobearer`


### PR DESCRIPTION
A URL https://serverest.js.org não está mais disponível.